### PR TITLE
Enable warning as error on CI

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install dependencies and build arrtifacts
+      - name: Install dependencies and build artifacts
         run: |
           npm install
-          CI=false npm run build
+          npm run build
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
* Reverted the explicit `CI` environment variable to `false` to allow warnings be treated as errors
* Fix a typo
