### PR TITLE
Handle errors during check-url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ware",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/App.js
+++ b/src/App.js
@@ -78,7 +78,6 @@ export default function App() {
         }
 
         const myEndpoint = convertPathToArticleEndpoint(pathName, refresh);
-        console.log("APP::articleFetch: endpoint = ", myEndpoint)
         setEndpointPath(myEndpoint); // for display
 
         // TODO: ERR: maybe always clear pageData, so components get cleared while waiting?
@@ -105,12 +104,15 @@ export default function App() {
             })
 
             .catch((err) => {
-                // TODO: set false pageData for display?
+
                 if (err.message === "404") {
-                    setMyError("Error finding target page.")
+                    setMyError("404: Error finding target page. err.toString():" + err.toString())
+                } else if (err.toString() === 'TypeError: Failed to fetch') {
+                    setMyError(err.toString() + ' (probably a CORS error)')
                 } else {
                     setMyError(err.toString())
                 }
+                // set false pageData for display - TODO: is this correct?
                 setPageData(null);
 
             })
@@ -146,8 +148,8 @@ export default function App() {
 
     // fetch initial article if specified on address bar with url param
     useEffect(() => {
-        debugAlert(`APP:::useEffect[myUrl, myRefresh]: calling handlePathName: ${myUrl}, ${myRefresh}`)
-        console.log(`APP:::useEffect[myUrl, myRefresh]: calling handlePathName: ${myUrl}, ${myRefresh}`)
+        debugAlert(`APP:::useEffect[myUrl, myRefresh]: calling articleFetch: ${myUrl}, ${myRefresh}`)
+        console.log(`APP:::useEffect[myUrl, myRefresh]: calling articleFetch: ${myUrl}, ${myRefresh}`)
 
         // set these states only for debugging, essentially
         setTargetPath(myUrl);

--- a/src/components/PageDisplay.js
+++ b/src/components/PageDisplay.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PageDisplayV2 from "./v2/PageDisplayV2";
 
-
 export default function PageDisplay( { pageData }) {
 
     if (!pageData) return <p>No page data</p>;

--- a/src/components/PieChart.js
+++ b/src/components/PieChart.js
@@ -60,7 +60,7 @@ export default function PieChart({ chartData, options, onClick }) {
         }
     }
 
-    console.log("loading pie chart");
+    console.log("Loading pie chart");
 
     return (
         <div className="chart-container">

--- a/src/components/v2/PageData.js
+++ b/src/components/v2/PageData.js
@@ -6,6 +6,7 @@ import Flds from "./Flds";
 import { API_V2_URL_BASE } from '../../constants/endpoints.js';
 import { URL_FILTER_MAP } from "./filters/urlFilterMaps.js";
 import Loader from "../Loader";
+import ArrayDisplay from "../ArrayDisplay";
 
 export default function PageData( { pageData = {} }) {
 
@@ -16,24 +17,11 @@ export default function PageData( { pageData = {} }) {
     const [urlOverview, setUrlOverview] = useState({}); // overview statistics for Urls; set in effects, passed to PageOverview
     const [urlFilter, setUrlFilter] = useState( null ); // filter to apply to displayed refs
 
+    // const [timeoutCheckUrl, setTimeoutCheckUrl] = useState(24);
+    const timeoutCheckUrl = 30;
     const [isLoadingUrls, setIsLoadingUrls] = useState(false);
 
-    // async function fetchOneRef(refID) {
-    //     const endpoint = `${API_V2_URL_BASE}/statistics/reference/${refID}`;
-    //     console.log("fetchOneRef: ", endpoint)
-    //     const response = await fetch(endpoint);
-    //     const data = await response.json();
-    //     const status_code = response.status;
-    //     return { data, status_code };
-    // }
-    // async function fetchAllRefs(refIDs) {
-    //     const promises = refIDs.map(refID => {
-    //         // console.log("fetchAllRefs: fetching: ", ref)
-    //         return fetchOneRef(refID) // ?? return fetchOneRef(refID).data?
-    //     });
-    //     const results = await Promise.all(promises);
-    //     return results;
-    // }
+    const [showDetail, setShowDetail] = useState(false);
 
     // calc ref overview data when pageData changes
     useEffect( () => {
@@ -43,49 +31,79 @@ export default function PageData( { pageData = {} }) {
     }, [pageData]) // TODO: change deps to [] ?
 
 
+    // returns an object:
+    //  {
+    //      data: {...url info...},
+    //      status_code: XXX
+    //  }
     async function fetchOneUrl(url, refresh=false, timeout=0) {
 
         const endpoint = `${API_V2_URL_BASE}/check-url`
             + `?url=${encodeURIComponent(url)}`
             + (refresh ? "&refresh=true" : '')
-            + (timeout > 0 ? `&timeout=${timeout}` : '')
-        ;
+            + (timeout > 0 ? `&timeout=${timeout}` : '');
+
+        let status_code;
 
         // TODO: do we want no-cache, even if no refresh?
-        const response = await fetch(endpoint, {cache: "no-cache"});
-        console.log("return from fetch for endpoint: ", endpoint )
-        const data = await response.json();
+        const urlData = await fetch(endpoint, {cache: "no-cache"})
+            // THIS IS WHERE 504 is happening!
+            .then( response => {
+                status_code = response.status
+                // console.log("fetchOneUrl: fetch:then: response:", response )
+                if (response.ok) {
+                    return response.json()
+                } else {
+                    // TODO: would be nice to use response.statusText, but
+                    // as of 2023.04.08, response.statusText is empty
+                    return Promise.resolve({
+                        url: url,
+                        status_code: 0,
+                        status_text: response.statusText,
+                        error_text: "error from archive server"
+                    })
+                }
+            })
 
-        const status_code = response.status; // Note: status_code is from the check-url call, NOT the target url
-        return { data, status_code };
+            .catch( (err) => {
+                status_code=0; // something bad happened in http request
+                console.warn(`fetchOneUrl: Erro when fetching url: ${url}, error: ${err.message}`)
+
+                // return fake url data object so URL display interface is not broken
+                Promise.resolve({
+                    url: url,
+                    status_code: 0,
+                    status_text: "unknown",
+                    error_text: "Failure during check-url",
+                    error_info: err.message
+                    })
+                }
+            );
+
+        return { data: urlData, status_code: status_code };
     }
 
     async function fetchAllUrls(urls, refresh=false) {
         if (!urls) return [];
-        const timeout=29; // # seconds, for now...
-        console.log(`fetchAllUrls: refresh = ${refresh}, timeout = ${timeout}`)
         const promises = urls.map(url => {
-            return fetchOneUrl(url, refresh, timeout)
+            return fetchOneUrl(url, refresh, timeoutCheckUrl)
         });
         const results = await Promise.all(promises);
+        // console.log("fetchAllUrls: after Promise.all, results:" , results)
         return results;
-    }
-
-    // eslint-disable-next-line
-    const cleanUrl = ( url ) => {
-        return encodeURI( url )
     }
 
     // process fetched url array by simply saving results
     useEffect( () => {
         setIsLoadingUrls(true);
+
         fetchAllUrls(pageData.urls, pageData.forceRefresh)
             .then(urlResults => {
-                console.log(`After fetchAllUrls: ${urlResults.length} results found`);
+                console.log(`useEffect[pageData] fetchAllUrls.then: ${urlResults.length} results found`);
                 setUrlBigArray( urlResults );
             })
             .catch(error => {
-                console.error("After fetchAllUrls:", error);
+                console.error("useEffect[pageData] fetchAllUrls:catch:", error);
             })
 
             .finally(() => {
@@ -117,7 +135,39 @@ export default function PageData( { pageData = {} }) {
         ? pageData.reference_details // "old" way
         : pageData.dehydrated_references
 
+    if ( !pageData ) return <>
+        <p>Nothing to display - pageData is missing.</p>
+    </>
+
     return <>
+
+        <h3>Page Analyzed: <a href={pageData.pathName} target={"_blank"} rel={"noreferrer"}>{pageData.pathName}</a
+            > <button onClick={() => setShowDetail(!showDetail)}
+                  className={"more-button"}>{showDetail ? "less" : "more"} details
+            </button>
+        </h3>
+
+        <div className={showDetail ? "detail-show" : "detail-hide"}>
+            <div className={"page-info-detail"}>
+                <p>endpoint: <a href={pageData.endpoint} target={"_blank"} rel={"noreferrer"}>{pageData.endpoint}</a></p>
+                <p>timeout for check-url: {timeoutCheckUrl}</p>
+                <div className={"page-info-grid"}>
+                    <ArrayDisplay arr={[
+                        {'WARI JSON version': pageData.version},
+                        {'lang': pageData.lang},
+                        {'site': pageData.site},
+                        {'title': pageData.title},
+                    ]}/>
+                    <ArrayDisplay arr={[
+                        {'wari_id': pageData.wari_id},
+                        {'page id': pageData.page_id},
+                        {'timestamp': pageData.timestamp ? new Date(pageData.timestamp * 1000).toString() : ""}, // times 1000 b/c of milliseconds
+                        {'timing': pageData["timing"]},
+                    ]} styleObj={{marginLeft: "1em"}}/>
+                </div>
+            </div>
+        </div>
+
 
         <PageOverview
             references={references}

--- a/src/components/v2/PageDisplayV2.js
+++ b/src/components/v2/PageDisplayV2.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PageInfo from "./PageInfo.js";
 import PageData from "./PageData.js";
 import './refs.css';
 
@@ -7,7 +6,6 @@ import './refs.css';
 export default function PageDisplayV2( { pageData }) {
 
     return <>
-        <PageInfo pageData={pageData} />
         <PageData pageData={pageData} />
     </>
 }

--- a/src/components/v2/PageOverview.js
+++ b/src/components/v2/PageOverview.js
@@ -230,7 +230,7 @@ export default function PageOverview( { references,
     // console.log("urlOverview:", urlOverview);
 
     return <div className={"page-overview"}>
-        <h3>Page Overview</h3>
+        {/*<h3>Page Overview</h3>*/}
         <div className={"page-overview-wrap"}>
 
             <UrlOverview overview={urlOverview} onClickChart={handleUrlButton}/>

--- a/src/components/v2/Urls.js
+++ b/src/components/v2/Urls.js
@@ -21,6 +21,7 @@ export default function Urls( { urlArray, filter } ) {
         urlDisplay = <p>No URLs to show!</p>;
     }
     else {
+        // TODO: data sanity check of urlArray elements: data, status_code, url, etc.
         const filteredUrls = filter
             ? urlArray.filter( (filter.filterFunction)() )
             : urlArray;
@@ -51,7 +52,7 @@ export default function Urls( { urlArray, filter } ) {
 
         urlDisplay = <>
             <h4 style={{color:"grey"}}>{label}</h4>
-            {/* USE ONLY WHEN DEBUG <p>sort = {sort?"true":"false"}</p>*/}
+            {/* TODO: SHOW ONLY WHEN DEBUG ON <p>sort = {sort?"true":"false"}</p>*/}
             <div className={"url-display"}>
                 <div className={"url-row url-header-row"}>
                     <div className={"url-name"} >url</div>

--- a/src/components/v2/refs.css
+++ b/src/components/v2/refs.css
@@ -11,6 +11,17 @@
 .page-overview-wrap > div {
     margin-right:1.25rem;
 }
+.page-info-detail {
+    display:block;
+    border:1px solid black;
+    padding: 0 1rem 1rem;
+    margin-bottom: 1rem;
+}
+.page-info-grid {
+    display: flex;
+    flex-direction: row;
+}
+
 
 .reference-types {
     display:flex;

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,6 @@ body.env-other .version-display span.non-production {
 
 .detail-show {
     display:inherit;
-    margin-bottom:1rem;
 }
 .detail-hide {
     display:none;


### PR DESCRIPTION
Sometimes the check-url endpoint from archive.org returns a 504 error code, breaking the UI.

Error handling is now in place to handle these errors and insert a fake object of url info for erroneous check-url fetches.

see PageData:: fetchOneUrl